### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Also included are 6 utilities, each with a different purpose.  Each utility has 
 * ddoSutil-gpblock.sh
 	* Some *ddos* attacks make GET/PUT requests to invalid URLs.  This will…
 	* Build block lists based on requests made to apache and actively drop the offending IPs.
-	* Configureable, ability to control how many requests per offending IP to resource, allowed.
+	* Configurable, ability to control how many requests per offending IP to resource, allowed.
 * ddoSutil-nstat.sh
 	* 	Shows information helpful to determine the help type of attack.
 * ddoSutil-mySQLrecover.pl


### PR DESCRIPTION
@vigeek, I've corrected a typographical error in the documentation of the [ddoSutil](https://github.com/vigeek/ddoSutil) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
